### PR TITLE
Add s3 getSignedUrl mock

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,14 @@ Available:
 - getObject
 - putObject
 - copyObject
+- getSignedUrl
 
 It uses a directory to mock a bucket and its content.
 
 If you'd like to see some more features or you have some suggestions, feel free to use the issues or submit a pull request.
 
 ## Release History
+* 2015-08-19   v0.2.8   Mock out AWS' S3 getSignedUrl function by @johnelliott
 * 2015-03-15   v0.2.7   Mock out AWS' config submodule by @necaris
 * 2015-03-13   v0.2.6   Partial match support and ContentLength by @mick
 * 2015-03-03   v0.2.5   Allow string and fix tests by @lbud

--- a/lib/mock.js
+++ b/lib/mock.js
@@ -13,6 +13,7 @@ var fs = require('fs-extra');
 var crypto = require('crypto');
 var path = require('path');
 var Buffer = require('buffer').Buffer;
+var format = require("util").format;
 
 // Gathered from http://stackoverflow.com/questions/5827612/node-js-fs-readdir-recursive-directory-search
 exports.walk = function (dir) {
@@ -197,4 +198,13 @@ exports.putObject = function (search, callback) {
 
 		search.Body.pipe(stream);
 	}
+};
+
+// returns a string
+exports.getSignedUrl = function (operation, params, callback) {
+	if (!params || !params.Bucket || !params.Key) {
+		return callback(new Error("Error: bad params"));
+	}
+	var result = format("https://s3.amazonaws.com/%s/%s", params.Bucket, params.Key);
+	return callback(null, result);
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mock-aws-s3",
   "description": "Mock AWS S3 SDK for Node.js",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "homepage": "https://github.com/MathieuLoutre/mock-aws-s3",
   "author": {
     "name": "Mathieu Triay",

--- a/test/test.js
+++ b/test/test.js
@@ -316,4 +316,26 @@ describe('S3', function () {
 		expect(s3.config.update).to.be.a('function');
 	});
 
+	describe("getSignedUrl", function () {
+
+		it("should respond with a url string", function(done) {
+			var params = {Bucket: "myBucket", Key: "myKey"};
+			s3.getSignedUrl("getObject", params, function(err, data) {
+				expect(err).to.be.null;
+				expect(data).to.equal("https://s3.amazonaws.com/myBucket/myKey");
+				done();
+			});
+		});
+
+		it("should respond with an error with incomplete params", function(done) {
+			// missing Bucket key
+			var params = {Key: "myKey"};
+			s3.getSignedUrl("getObject", params, function(err, data) {
+				expect(err).to.match(/Error/);
+				done();
+			});
+		});
+
+	});
 });
+


### PR DESCRIPTION
@necaris would you review this?

Add a basic mock for the getSignedUrl fucntion: http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#getSignedUrl-property

This ignores the `operation` because the url doesn't go to a server that restricts methods.
